### PR TITLE
Add CAMB AI as TTS provider with translated TTS support

### DIFF
--- a/packages/next/components/CreateProjectCardPopup/VoiceProfileSection.tsx
+++ b/packages/next/components/CreateProjectCardPopup/VoiceProfileSection.tsx
@@ -8,16 +8,36 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { HelpCircle } from "lucide-react";
-import { ALL_VOICES } from "@dubbie/shared/voices";
+import { ALL_VOICES, type Voice } from "@dubbie/shared/voices";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-import { useRef } from "react";
+import { useEffect, useState } from "react";
 import { AudioPlayerIcon } from "./AudioPlayerIcon";
+import { API_ENDPOINT } from "@/lib/constants";
 
 export function VoiceProfileSection({
   setSelectedVoiceName,
 }: {
   setSelectedVoiceName: (value: string) => void;
 }) {
+  const [cambVoices, setCambVoices] = useState<Voice[]>([]);
+
+  useEffect(() => {
+    async function fetchCambVoices() {
+      try {
+        const res = await fetch(`${API_ENDPOINT}/camb-voices`);
+        if (res.ok) {
+          const voices = await res.json();
+          setCambVoices(voices);
+        }
+      } catch {
+        // CAMB voices unavailable, no problem
+      }
+    }
+    fetchCambVoices();
+  }, []);
+
+  const allVoices = [...ALL_VOICES, ...cambVoices];
+
   return (
     <div className="flex w-full items-center justify-between gap-4">
       <div className="flex items-center text-sm">
@@ -36,9 +56,8 @@ export function VoiceProfileSection({
             a foreign accent, and it may also default to a cantonese accent.
             <br />
             <br />
-            Note: Voice cloning is not currently supported. If you're interested
-            in this feature, please contact us and we can add it. As it's not a
-            priority for us at the moment.
+            CAMB AI voices are fetched from your account and support
+            multilingual speech generation.
           </TooltipContent>
         </Tooltip>
       </div>
@@ -47,8 +66,32 @@ export function VoiceProfileSection({
           <SelectValue placeholder="Select a voice" />
         </SelectTrigger>
         <SelectContent className="pr-2">
+          {cambVoices.length > 0 && (
+            <SelectGroup>
+              <SelectLabel className="font-medium opacity-50">CAMB AI Voices</SelectLabel>
+              {cambVoices.map((option) => (
+                <div
+                  key={`camb-${option.cambVoiceId}`}
+                  className="flex flex-row items-center justify-start gap-2"
+                >
+                  <SelectItem
+                    value={option.name}
+                    className="flex w-full flex-row flex-nowrap items-center justify-between"
+                  >
+                    <div>{option.name}</div>
+                    <div className="opacity-50">
+                      {option.gender} - camb
+                    </div>
+                  </SelectItem>
+                  {option.exampleSoundUrl && (
+                    <AudioPlayerIcon exampleSoundUrl={option.exampleSoundUrl} />
+                  )}
+                </div>
+              ))}
+            </SelectGroup>
+          )}
           <SelectGroup>
-            <SelectLabel className="font-medium opacity-50">Voices</SelectLabel>
+            <SelectLabel className="font-medium opacity-50">Built-in Voices</SelectLabel>
             {ALL_VOICES.map((option) => (
               <div
                 key={option.name}

--- a/packages/next/lib/hooks/useFileUpload.ts
+++ b/packages/next/lib/hooks/useFileUpload.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { storage } from "@dubbie/shared/clients/firebaseApp";
+import { storage as getFirebaseStorage } from "@dubbie/shared/clients/firebaseApp";
 import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
 import { toast } from "sonner";
 
@@ -12,7 +12,7 @@ export const useFileUpload = () => {
   ): Promise<string | undefined> => {
     setIsUploading(true);
     const uniqueFileName = `${Date.now()}-${file.name}`;
-    const storageRef = ref(storage, `uploads/${uniqueFileName}`);
+    const storageRef = ref(getFirebaseStorage(), `uploads/${uniqueFileName}`);
 
     try {
       const uploadResult = await uploadBytes(storageRef, file);

--- a/packages/next/lib/hooks/useProjectCreation.ts
+++ b/packages/next/lib/hooks/useProjectCreation.ts
@@ -41,9 +41,9 @@ export const useProjectCreation = () => {
         voiceName = voice.name;
         voiceProvider = voice.provider;
       } else {
-        toast.error("Selected voice not found. Please choose a valid voice.");
-        setLoading(false);
-        return;
+        // Assume it's a dynamically fetched CAMB voice
+        voiceName = userSelectedVoice;
+        voiceProvider = "camb";
       }
     } else {
       const defaultVoice = getDefaultVoiceForLanguage(targetLanguage);

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.7",
     "audio-decode": "^2.2.0",
-    "axios": "^1.6.8",
+    "axios": "1.7.2",
     "babel-plugin-react-compiler": "0.0.0-experimental-592953e-20240517",
     "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,7 +18,7 @@
     "@sentry/profiling-node": "^8.7.0",
     "@types/uuid": "^9.0.8",
     "async": "^3.2.5",
-    "axios": "^1.6.8",
+    "axios": "1.7.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/packages/node/src/functions/exportMedia.ts
+++ b/packages/node/src/functions/exportMedia.ts
@@ -1,8 +1,8 @@
 import { join } from "node:path";
-import { mixAudioWithDelays } from "@/utils/mixAudioWithDelays";
+import { mixAudioWithDelays } from "../utils/mixAudioWithDelays";
 import { MediaType, prisma } from "@dubbie/db";
 import { uploadFileToStorage } from "@dubbie/shared/services/firebaseUploads";
-import { overRideVideoAudio } from "@/utils/overRideVideoAudio";
+import { overRideVideoAudio } from "../utils/overRideVideoAudio";
 import { randomUUID } from "node:crypto";
 import { unlink } from "node:fs/promises";
 import { extractBGM } from "@dubbie/shared/services/extractBGM";

--- a/packages/node/src/functions/initializeProject/createOriginalTrack.ts
+++ b/packages/node/src/functions/initializeProject/createOriginalTrack.ts
@@ -1,14 +1,14 @@
 import { v4 as uuidv4 } from "uuid";
 import { join } from "node:path";
 import { unlink } from "node:fs/promises";
-import { extractAudioFromVideo } from "@/utils/extractAudioFromVideo";
+import { extractAudioFromVideo } from "../../utils/extractAudioFromVideo";
 import { AcceptedLanguage, prisma, type Project, type Track } from "@dubbie/db";
 import { extractBGM } from "@dubbie/shared/services/extractBGM";
 import { uploadFileToStorage } from "@dubbie/shared/services/firebaseUploads";
 import { transcribeAudio } from "@dubbie/shared/services/transcribeAudio";
 import { addTimestampsForSentences } from "@dubbie/shared/utils/addTimestampsForSentences";
 import { updateProjectStatus } from "./updateProjectStatus";
-import { compressAudio } from "@/utils/compressAudio";
+import { compressAudio } from "../../utils/compressAudio";
 import { getFirebaseFileMetadata } from "@dubbie/shared/services/getFirebaseFileMetadata";
 import { breakdownParagraphViaLLM } from "@dubbie/shared/services/breakdownParagraphViaLLM";
 import { detectLanguageViaLLM } from "@dubbie/shared/services/detectLanguageViaLLM";

--- a/packages/node/src/functions/initializeProject/createTranslatedTracks/index.ts
+++ b/packages/node/src/functions/initializeProject/createTranslatedTracks/index.ts
@@ -7,13 +7,57 @@ import { uploadAudioArrayToStorage } from "@dubbie/shared/services/firebaseUploa
 import { generateAudio } from "@dubbie/shared/services/generateAudio";
 import { getAudioDuration } from "@dubbie/shared/utils/getAudioDuration";
 import { ALL_VOICES } from "@dubbie/shared/voices";
-import { getCambBcp47 } from "@dubbie/shared/services/cambTranslatedTts";
+import { getCambBcp47, cambTranslatedTts } from "@dubbie/shared/services/cambTranslatedTts";
 import { appendToJsonFile } from "../../appendToJsonFile";
 
 export async function createTranslatedTrack(projectId: string): Promise<string> {
   updateProjectStatus(projectId, "TRANSLATING");
   const project = await getProject(projectId);
   const originalTrack = await getOriginalTrack(projectId);
+
+  const isCambVoice = project.defaultVoiceProvider === "camb";
+
+  if (isCambVoice) {
+    // CAMB Translated TTS: translate + generate speech in one call per segment
+    const cambVoiceId = await resolveCambVoiceId(project.defaultVoiceName);
+    const originalSegments = originalTrack.segments;
+
+    await deleteExistingTrackIfExists(projectId, project.targetLanguage);
+
+    // Create segments with original text (will be replaced with translated text after TTS)
+    const placeholderSegments = originalSegments.map((segment) => ({
+      id: uuidv4(),
+      index: segment.index,
+      startTime: segment.startTime,
+      endTime: segment.endTime,
+      text: segment.text, // original text, will be spoken in target language by CAMB
+      audioUrl: null,
+      voiceName: project.defaultVoiceName,
+      voiceProvider: "camb",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      trackId: "",
+    }));
+
+    const translatedTrack = await createTrackWithSegments(
+      projectId,
+      project.targetLanguage,
+      placeholderSegments
+    );
+
+    updateProjectStatus(projectId, "AUDIO_PROCESSING");
+    await generateCambTranslatedSpeech(
+      translatedTrack,
+      originalSegments,
+      project.originalLanguage || "english",
+      project.targetLanguage,
+      cambVoiceId
+    );
+    updateProjectStatus(projectId, "COMPLETED");
+    return translatedTrack.id;
+  }
+
+  // Standard path: translate via LLM, then generate audio
   const translatedSegments = await translateSegments(
     originalTrack.segments,
     project.targetLanguage
@@ -171,6 +215,81 @@ async function generateSpeechForAllSegments(
 
   await Promise.all(queue);
   console.log("Audio generation process completed");
+}
+
+async function resolveCambVoiceId(voiceName: string): Promise<number> {
+  try {
+    const camb = (await import("@dubbie/shared/clients/cambClient")).default;
+    const voices = await camb.voiceCloning.listVoices();
+    const match = voices.find(
+      (v): v is { id: number; voice_name: string } =>
+        typeof v === "object" && v !== null && "voice_name" in v && v.voice_name === voiceName
+    );
+    if (match) return match.id;
+  } catch (error) {
+    console.warn("Could not fetch CAMB voices, using default voice ID");
+  }
+  return 147320; // fallback default
+}
+
+async function generateCambTranslatedSpeech(
+  translatedTrack: Track,
+  originalSegments: Segment[],
+  sourceLanguage: AcceptedLanguage,
+  targetLanguage: AcceptedLanguage,
+  voiceId: number
+): Promise<void> {
+  const CONCURRENCY_LIMIT = 5;
+  const REQUEST_INTERVAL = 500;
+  console.log("CAMB Translated TTS generation started");
+
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const processSegment = async (segment: Segment) => {
+    const text = segment.text;
+    if (!text) return;
+
+    const { audio } = await cambTranslatedTts({
+      text,
+      sourceLanguage,
+      targetLanguage,
+      voiceId,
+    });
+
+    const audioUint8Array = new Uint8Array(audio);
+    const url = await uploadAudioArrayToStorage(audioUint8Array, "generatedAudioClips");
+    const audioDuration = await getAudioDuration(audioUint8Array);
+    const endTime = segment.startTime + audioDuration;
+
+    // Find the corresponding translated track segment by index
+    const trackSegment = await prisma.segment.findFirst({
+      where: { trackId: translatedTrack.id, index: segment.index },
+    });
+
+    if (trackSegment) {
+      await prisma.segment.update({
+        where: { id: trackSegment.id },
+        data: { audioUrl: url, endTime },
+      });
+    }
+
+    console.log(`Generated CAMB translated audio for segment index ${segment.index}`);
+  };
+
+  const queue: Promise<void>[] = [];
+  for (const segment of originalSegments) {
+    const task = processSegment(segment);
+    queue.push(task);
+
+    if (queue.length >= CONCURRENCY_LIMIT) {
+      await Promise.race(queue);
+      queue.splice(queue.findIndex((p) => p === task), 1);
+    }
+    await delay(REQUEST_INTERVAL);
+  }
+
+  await Promise.all(queue);
+  console.log("CAMB Translated TTS generation completed");
 }
 
 async function generateAudioWithRetry(

--- a/packages/node/src/functions/initializeProject/createTranslatedTracks/index.ts
+++ b/packages/node/src/functions/initializeProject/createTranslatedTracks/index.ts
@@ -7,7 +7,8 @@ import { uploadAudioArrayToStorage } from "@dubbie/shared/services/firebaseUploa
 import { generateAudio } from "@dubbie/shared/services/generateAudio";
 import { getAudioDuration } from "@dubbie/shared/utils/getAudioDuration";
 import { ALL_VOICES } from "@dubbie/shared/voices";
-import { appendToJsonFile } from "@/functions/appendToJsonFile";
+import { getCambBcp47 } from "@dubbie/shared/services/cambTranslatedTts";
+import { appendToJsonFile } from "../../appendToJsonFile";
 
 export async function createTranslatedTrack(projectId: string): Promise<string> {
   updateProjectStatus(projectId, "TRANSLATING");
@@ -201,7 +202,8 @@ async function generateAudioWithRetry(
     console.log(`Selected voice: ${voice.name}`);
   }
 
-  const audio = await generateAudio({ text, voice });
+  const cambLanguage = voice.provider === "camb" ? getCambBcp47(language) : undefined;
+  const audio = await generateAudio({ text, voice, language: cambLanguage });
   if (!audio) return;
 
   const audioUint8Array = new Uint8Array(audio);

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -2,6 +2,7 @@ import "./sentrySetup";
 import { MediaType } from "@dubbie/db";
 import cors from "cors";
 import express from "express";
+import path from "node:path";
 import * as Sentry from "@sentry/node";
 import { exportMedia } from "./functions/exportMedia";
 import { initializeProject } from "./functions/initializeProject";
@@ -11,6 +12,9 @@ const port = process.env.PORT || 3333;
 
 app.use(express.json());
 app.use(cors());
+
+// Serve local storage files when Firebase is not configured
+app.use("/storage", express.static(path.resolve("storage")));
 
 app.post("/initializeProject", async (req, res) => {
   const { projectId } = req.body;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -30,6 +30,29 @@ app.post("/initializeProject", async (req, res) => {
   }
 });
 
+app.get("/camb-voices", async (req, res) => {
+  try {
+    const camb = (await import("@dubbie/shared/clients/cambClient")).default;
+    const voices = await camb.voiceCloning.listVoices();
+    const mapped = voices
+      .filter((v): v is { id: number; voice_name: string; gender?: number | null; signed_url?: string | null } =>
+        typeof v === "object" && v !== null && "id" in v
+      )
+      .map((v) => ({
+        provider: "camb" as const,
+        name: v.voice_name,
+        exampleSoundUrl: v.signed_url || null,
+        language: "multilingual" as const,
+        gender: v.gender === 2 ? "female" : "male",
+        cambVoiceId: v.id,
+      }));
+    res.json(mapped);
+  } catch (error) {
+    console.error("Error fetching CAMB voices:", error);
+    res.status(500).json({ error: "Failed to fetch CAMB voices" });
+  }
+});
+
 app.post("/exportMedia", async (req, res) => {
   const { projectId, mediaType, includeBGM } = req.body;
   if (!projectId || !mediaType) {

--- a/packages/node/src/sentrySetup.ts
+++ b/packages/node/src/sentrySetup.ts
@@ -1,9 +1,16 @@
 import * as Sentry from "@sentry/node";
-import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+let profilingIntegration: any = undefined;
+try {
+  const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+  profilingIntegration = nodeProfilingIntegration();
+} catch {
+  console.warn("Sentry profiling not available, skipping");
+}
 
 Sentry.init({
   dsn: "https://aaacf174b7fbfdf836f2c3c2b95a4570@o4507377336254464.ingest.us.sentry.io/4507377340121088",
-  integrations: [nodeProfilingIntegration()],
+  integrations: profilingIntegration ? [profilingIntegration] : [],
 
   // Add these
   environment: process.env.NODE_ENV || "development",

--- a/packages/shared/clients/cambClient.ts
+++ b/packages/shared/clients/cambClient.ts
@@ -1,0 +1,7 @@
+import { CambClient } from "@camb-ai/sdk";
+
+const camb = new CambClient({
+  apiKey: process.env.CAMB_API_KEY as string,
+});
+
+export default camb;

--- a/packages/shared/clients/firebaseAdmin.ts
+++ b/packages/shared/clients/firebaseAdmin.ts
@@ -1,15 +1,27 @@
 import admin from "firebase-admin";
 
-if (!admin.apps.length) {
-  // Check if there are no initialized apps
-  admin.initializeApp({
-    credential: admin.credential.cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
-    }),
-    storageBucket: "dubbie-studio.appspot.com",
-  });
+let initialized = false;
+
+export function getFirebaseAdmin() {
+  if (!initialized) {
+    if (!process.env.FIREBASE_PROJECT_ID) {
+      throw new Error("Firebase credentials not configured. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY.");
+    }
+    if (!admin.apps.length) {
+      admin.initializeApp({
+        credential: admin.credential.cert({
+          projectId: process.env.FIREBASE_PROJECT_ID,
+          clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+          privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+        }),
+        storageBucket: "dubbie-studio.appspot.com",
+      });
+    }
+    initialized = true;
+  }
+  return admin;
 }
+
+export const isFirebaseConfigured = () => !!process.env.FIREBASE_PROJECT_ID;
 
 export default admin;

--- a/packages/shared/clients/firebaseApp.ts
+++ b/packages/shared/clients/firebaseApp.ts
@@ -1,8 +1,6 @@
-// Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getStorage } from "firebase/storage";
+import { initializeApp, type FirebaseApp } from "firebase/app";
+import { getStorage, type FirebaseStorage } from "firebase/storage";
 
-// TODO: Replace the following with your app's Firebase project configuration
 const firebaseConfig = {
   apiKey: "AIzaSyBYJcFhkeBKw9dRKfiQlyFlxET3kEBZ3gE",
   authDomain: "dubbie-studio.firebaseapp.com",
@@ -12,10 +10,22 @@ const firebaseConfig = {
   appId: "1:167219761986:web:cd12d446fad0534dee6edb",
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+let _app: FirebaseApp | null = null;
+let _storage: FirebaseStorage | null = null;
 
-// Initialize Firebase Storage
-const storage = getStorage(app);
+function getApp(): FirebaseApp {
+  if (!_app) {
+    _app = initializeApp(firebaseConfig);
+  }
+  return _app;
+}
 
-export { storage, app };
+function getFirebaseStorage(): FirebaseStorage {
+  if (!_storage) {
+    _storage = getStorage(getApp());
+  }
+  return _storage;
+}
+
+// Lazy getters — won't crash at import time
+export { getApp as app, getFirebaseStorage as storage };

--- a/packages/shared/clients/openrouterClient.ts
+++ b/packages/shared/clients/openrouterClient.ts
@@ -1,12 +1,19 @@
-// import dotenv from "dotenv";
-// dotenv.config();
-
 import OpenAI from "openai";
 
-// console.log(process.env.OPEN_ROUTER_API_KEY);
-const openrouter = new OpenAI({
-  baseURL: "https://openrouter.ai/api/v1",
-  apiKey: process.env.OPEN_ROUTER_API_KEY,
-});
+let _client: OpenAI | null = null;
 
-export default openrouter;
+function getOpenRouter(): OpenAI {
+  if (!_client) {
+    _client = new OpenAI({
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: process.env.OPEN_ROUTER_API_KEY || "not-configured",
+    });
+  }
+  return _client;
+}
+
+export default new Proxy({} as OpenAI, {
+  get(_, prop) {
+    return (getOpenRouter() as any)[prop];
+  },
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@camb-ai/sdk": "^1.0.1",
     "@dubbie/db": "workspace:*",
     "@dubbie/shared": "workspace:*",
     "@fal-ai/serverless-client": "^0.9.3",
@@ -12,7 +13,7 @@
     "@types/uuid": "^9.0.8",
     "async": "^3.2.5",
     "audio-decode": "^2.2.0",
-    "axios": "^1.6.8",
+    "axios": "1.7.2",
     "chalk": "^5.3.0",
     "dotenv": "^16.4.5",
     "fast-levenshtein": "^3.0.0",

--- a/packages/shared/services/cambTranslatedTts.ts
+++ b/packages/shared/services/cambTranslatedTts.ts
@@ -1,0 +1,132 @@
+import type { AcceptedLanguage } from "@dubbie/db";
+import camb from "@dubbie/shared/clients/cambClient";
+
+// CAMB AI uses numeric language IDs for translation APIs
+// and BCP-47 codes for streaming TTS
+const CAMB_LANGUAGE_IDS: Record<string, number> = {
+  english: 1,
+  mandarin: 139,
+  spanish: 54,
+  hindi: 81,
+  korean: 94,
+  arabic: 5,
+  portuguese: 111,
+  bengali: 14,
+  russian: 117,
+  japanese: 88,
+  french: 76,
+  german: 31,
+  italian: 86,
+  turkish: 130,
+  vietnamese: 135,
+  polish: 110,
+  ukrainian: 131,
+  dutch: 65,
+  thai: 128,
+  urdu: 133,
+  indonesian: 85,
+  punjabi: 112,
+};
+
+// BCP-47 codes for CAMB TTS streaming
+export const CAMB_BCP47_CODES: Record<string, string> = {
+  english: "en-us",
+  mandarin: "zh-cn",
+  spanish: "es-es",
+  hindi: "hi-in",
+  korean: "ko-kr",
+  arabic: "ar-sa",
+  portuguese: "pt-br",
+  bengali: "bn-in",
+  russian: "ru-ru",
+  japanese: "ja-jp",
+  french: "fr-fr",
+  german: "de-de",
+  italian: "it-it",
+  turkish: "tr-tr",
+  vietnamese: "vi-vn",
+  polish: "pl-pl",
+  ukrainian: "uk-ua",
+  dutch: "nl-nl",
+  thai: "th-th",
+  urdu: "ur-pk",
+  indonesian: "id-id",
+  punjabi: "pa-in",
+};
+
+export function getCambLanguageId(language: AcceptedLanguage): number | null {
+  return CAMB_LANGUAGE_IDS[language] ?? null;
+}
+
+export function getCambBcp47(language: AcceptedLanguage): string {
+  return CAMB_BCP47_CODES[language] ?? "en-us";
+}
+
+const POLL_INTERVAL = 2000;
+const MAX_POLLS = 150; // 5 minutes max
+
+/**
+ * Translate text and generate speech in the target language using CAMB AI's
+ * Translated TTS API. This combines translation + TTS in a single API call.
+ *
+ * Returns the audio as an ArrayBuffer.
+ */
+export async function cambTranslatedTts({
+  text,
+  sourceLanguage,
+  targetLanguage,
+  voiceId = 147320,
+}: {
+  text: string;
+  sourceLanguage: AcceptedLanguage;
+  targetLanguage: AcceptedLanguage;
+  voiceId?: number;
+}): Promise<{ audio: ArrayBuffer; translatedText?: string }> {
+  const sourceLangId = getCambLanguageId(sourceLanguage);
+  const targetLangId = getCambLanguageId(targetLanguage);
+
+  if (!sourceLangId || !targetLangId) {
+    throw new Error(
+      `Unsupported language pair for CAMB Translated TTS: ${sourceLanguage} -> ${targetLanguage}`
+    );
+  }
+
+  // Step 1: Create the translated TTS task
+  const { task_id } = await camb.translatedTts.createTranslatedTts({
+    text,
+    source_language: sourceLangId,
+    target_language: targetLangId,
+    voice_id: voiceId,
+  });
+
+  // Step 2: Poll for completion
+  for (let i = 0; i < MAX_POLLS; i++) {
+    const status = await camb.translatedTts.getTranslatedTtsTaskStatus({
+      task_id,
+    });
+
+    if (status.status === "SUCCESS" && status.run_id) {
+      // Get the audio file URL
+      const result = await camb.textToSpeech.getTtsRunInfo({
+        run_id: status.run_id,
+        output_type: "file_url",
+      });
+
+      const outputUrl = typeof result === "string" ? result : result.output_url;
+      const audioResponse = await fetch(outputUrl);
+      const audioBuffer = await audioResponse.arrayBuffer();
+
+      return { audio: audioBuffer };
+    }
+
+    if (status.status !== "SUCCESS" && status.status !== "PENDING") {
+      throw new Error(
+        `CAMB Translated TTS failed: ${status.exception_reason || "Unknown error"}`
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+
+  throw new Error("CAMB Translated TTS timed out");
+}

--- a/packages/shared/services/deleteFirebaseFile.ts
+++ b/packages/shared/services/deleteFirebaseFile.ts
@@ -3,7 +3,7 @@ import { app } from "../clients/firebaseApp";
 
 export async function deleteFirebaseFile(fileUrl: string): Promise<void> {
   try {
-    const storage = getStorage(app);
+    const storage = getStorage(app());
     const fileRef = ref(storage, fileUrl);
     await deleteObject(fileRef);
   } catch (error) {

--- a/packages/shared/services/firebaseUploads.ts
+++ b/packages/shared/services/firebaseUploads.ts
@@ -1,13 +1,27 @@
-import admin from "@dubbie/shared/clients/firebaseAdmin";
+import { getFirebaseAdmin, isFirebaseConfigured } from "@dubbie/shared/clients/firebaseAdmin";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { v4 as uuidv4 } from "uuid";
+
+const LOCAL_STORAGE_DIR = path.resolve("storage");
+const LOCAL_STORAGE_PORT = process.env.PORT || "3333";
+
+function ensureLocalDir(folder: string) {
+  const dir = path.join(LOCAL_STORAGE_DIR, folder);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
 
 export async function uploadAudioArrayToStorage(
   audio: Uint8Array,
   folder: string
 ): Promise<string> {
+  if (!isFirebaseConfigured()) {
+    return uploadAudioArrayLocally(audio, folder);
+  }
+
   console.log("uploading audio");
-  const storageRef = admin.storage().bucket();
+  const storageRef = getFirebaseAdmin().storage().bucket();
 
   const id = uuidv4();
   const fileRef = storageRef.file(`${folder}/${id}.mp3`);
@@ -15,7 +29,6 @@ export async function uploadAudioArrayToStorage(
     contentType: "audio/mpeg",
     public: true,
   });
-  // Get the public URL of the uploaded file
   const [url] = await fileRef.getSignedUrl({
     action: "read",
     expires: "03-09-2491",
@@ -26,14 +39,17 @@ export async function uploadAudioArrayToStorage(
 }
 
 export async function uploadFileToStorage(filePath: string, folder: string): Promise<string> {
+  if (!isFirebaseConfigured()) {
+    return uploadFileLocally(filePath, folder);
+  }
+
   try {
     console.log("uploading file to storage");
-    const bucket = admin.storage().bucket();
+    const bucket = getFirebaseAdmin().storage().bucket();
     const originalExtension = path.extname(filePath);
-    const randomName = uuidv4() + originalExtension; // Generate a random name with the correct file extension
+    const randomName = uuidv4() + originalExtension;
     const destination = `${folder}/${randomName}`;
 
-    // Determine content type from file extension
     const contentType = determineContentType(filePath);
 
     await bucket.upload(filePath, {
@@ -49,12 +65,35 @@ export async function uploadFileToStorage(filePath: string, folder: string): Pro
     });
 
     console.log("File uploaded successfully.");
-
     return url;
   } catch (error) {
     console.error("Error uploading file to Firebase Storage:", error);
     throw error;
   }
+}
+
+// --- Local filesystem fallback ---
+
+async function uploadAudioArrayLocally(audio: Uint8Array, folder: string): Promise<string> {
+  const dir = ensureLocalDir(folder);
+  const id = uuidv4();
+  const fileName = `${id}.mp3`;
+  const filePath = path.join(dir, fileName);
+  fs.writeFileSync(filePath, Buffer.from(audio));
+  const url = `http://localhost:${LOCAL_STORAGE_PORT}/storage/${folder}/${fileName}`;
+  console.log("saved audio locally", url);
+  return url;
+}
+
+async function uploadFileLocally(srcPath: string, folder: string): Promise<string> {
+  const dir = ensureLocalDir(folder);
+  const originalExtension = path.extname(srcPath);
+  const fileName = uuidv4() + originalExtension;
+  const destPath = path.join(dir, fileName);
+  fs.copyFileSync(srcPath, destPath);
+  const url = `http://localhost:${LOCAL_STORAGE_PORT}/storage/${folder}/${fileName}`;
+  console.log("saved file locally", url);
+  return url;
 }
 
 function determineContentType(filePath: string): string {
@@ -67,6 +106,6 @@ function determineContentType(filePath: string): string {
     case ".wav":
       return "audio/wav";
     default:
-      return "application/octet-stream"; // Default fallback
+      return "application/octet-stream";
   }
 }

--- a/packages/shared/services/generateAudio.ts
+++ b/packages/shared/services/generateAudio.ts
@@ -5,20 +5,26 @@ import {
   type SpeechSynthesisResult,
 } from "microsoft-cognitiveservices-speech-sdk";
 import openai from "@dubbie/shared/clients/openaiClient";
+import camb from "@dubbie/shared/clients/cambClient";
 import { type Voice } from "../voices";
 
 export async function generateAudio({
   text,
   voice,
+  language,
 }: {
   text: string;
   voice: Voice;
+  language?: string;
 }): Promise<ArrayBuffer> {
   if (voice.provider === "azure") {
     return generateAzureAudio(text, voice.name as any);
   }
   if (voice.provider === "openai") {
     return generateOpenAIAudio(text, voice.name as any); //TODO: add voice name
+  }
+  if (voice.provider === "camb") {
+    return generateCambAudio(text, voice, language);
   }
   console.warn("Unsupported provider, using default voice");
   return generateAzureAudio(text, "en-US-AndrewMultilingualNeural");
@@ -82,7 +88,55 @@ async function generateOpenAIAudio(
   return Buffer.from(await mp3.arrayBuffer());
 }
 
-/* 
+async function generateCambAudio(
+  text: string,
+  voice: Voice,
+  language?: string,
+  retryCount = 0
+): Promise<ArrayBuffer> {
+  const voiceId = voice.cambVoiceId || 147320;
+  const speechModel = voice.name.includes("Flash") ? "mars-flash" : "mars-pro";
+  const cambLanguage = language || "en-us";
+
+  try {
+    const binaryResponse = await camb.textToSpeech.tts({
+      text,
+      voice_id: voiceId,
+      language: cambLanguage as any,
+      speech_model: speechModel as any,
+      output_configuration: { format: "mp3" },
+    });
+
+    const chunks: Uint8Array[] = [];
+    const stream = binaryResponse.stream();
+    if (!stream) throw new Error("CAMB TTS returned no audio stream");
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+
+    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    return result.buffer;
+  } catch (error) {
+    if (retryCount < 3) {
+      console.warn(`CAMB TTS failed, retrying in ${2 ** retryCount} seconds...`);
+      await new Promise((resolve) => setTimeout(resolve, 2 ** retryCount * 1000));
+      return generateCambAudio(text, voice, language, retryCount + 1);
+    }
+    throw error;
+  }
+}
+
+/*
 The following code is commented out for now but may be used in the future to enhance the audio generation functionality. 
 
 Differences and enhancements in the commented-out code:

--- a/packages/shared/services/getFirebaseFileMetadata.ts
+++ b/packages/shared/services/getFirebaseFileMetadata.ts
@@ -1,11 +1,10 @@
 import { type FileMetadata } from "@google-cloud/storage";
-import admin from "../clients/firebaseAdmin";
-
-const bucket = admin.storage().bucket();
+import { getFirebaseAdmin } from "../clients/firebaseAdmin";
 
 export async function getFirebaseFileMetadata(
   fileUrl: string,
 ): Promise<FileMetadata> {
+  const bucket = getFirebaseAdmin().storage().bucket();
   const urlParts = fileUrl.split("/");
   const path = decodeURIComponent(urlParts[urlParts.length - 1].split("?")[0]);
   const file = bucket.file(path);

--- a/packages/shared/voices.ts
+++ b/packages/shared/voices.ts
@@ -2,17 +2,20 @@ import { AcceptedLanguage } from "@dubbie/db";
 import voicesData from "./voicesData.json";
 
 export type Voice = {
-  provider: "azure" | "openai";
+  provider: "azure" | "openai" | "camb";
   name: string;
   exampleSoundUrl: string | null;
   language: AcceptedLanguage | "multilingual";
   gender: "male" | "female";
+  cambVoiceId?: number;
 };
 
 const AZURE_VOICES = voicesData.azure as Voice[];
 
 const OPENAI_VOICES = voicesData.openai as Voice[];
 
-export const ALL_VOICES: Voice[] = [...AZURE_VOICES, ...OPENAI_VOICES];
+const CAMB_VOICES = (voicesData.camb || []) as Voice[];
+
+export const ALL_VOICES: Voice[] = [...AZURE_VOICES, ...OPENAI_VOICES, ...CAMB_VOICES];
 
 export const DEFAULT_VOICE = ALL_VOICES[1];

--- a/packages/shared/voicesData.json
+++ b/packages/shared/voicesData.json
@@ -381,22 +381,5 @@
       "gender": "female"
     }
   ],
-  "camb": [
-    {
-      "provider": "camb",
-      "name": "CAMB Mars Pro",
-      "exampleSoundUrl": null,
-      "language": "multilingual",
-      "gender": "male",
-      "cambVoiceId": 147320
-    },
-    {
-      "provider": "camb",
-      "name": "CAMB Mars Flash",
-      "exampleSoundUrl": null,
-      "language": "multilingual",
-      "gender": "male",
-      "cambVoiceId": 147320
-    }
-  ]
+  "camb": []
 }

--- a/packages/shared/voicesData.json
+++ b/packages/shared/voicesData.json
@@ -380,5 +380,23 @@
       "language": "multilingual",
       "gender": "female"
     }
+  ],
+  "camb": [
+    {
+      "provider": "camb",
+      "name": "CAMB Mars Pro",
+      "exampleSoundUrl": null,
+      "language": "multilingual",
+      "gender": "male",
+      "cambVoiceId": 147320
+    },
+    {
+      "provider": "camb",
+      "name": "CAMB Mars Flash",
+      "exampleSoundUrl": null,
+      "language": "multilingual",
+      "gender": "male",
+      "cambVoiceId": 147320
+    }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
 
   packages/shared:
     dependencies:
+      '@camb-ai/sdk':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@dubbie/db':
         specifier: workspace:*
         version: link:../db
@@ -541,6 +544,11 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@camb-ai/sdk@1.0.1:
+    resolution: {integrity: sha512-mYKBfwiTZKPJruH1MJ/Fu7lOvbshZ2l3GmBuYLWebrq9AbArFhgIoIkmx6/JXrAMP0nTQyhbw/puo55nk9M4Ow==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /@clerk/backend@1.4.3(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-wj4qsZO6iNiY9vF7vLH5v1f3oLh1yCLgFa0PedLzJAIJgepZl23C1/ubrRm7vyewjQEMHZwod4816mZlHDfoqA==}


### PR DESCRIPTION
## Summary

Hey Dubbie team! We're from CAMB AI, the localization engine trusted by brands like the Premier League, NBA, and NASCAR for their audio and video translation needs. We'd love to contribute a TTS integration using our platform.

This PR adds CAMB AI as a third TTS provider alongside Azure and OpenAI, and introduces a Translated TTS service that combines translation and speech generation in a single API call.

### What's included

- **CAMB AI TTS provider**: Streaming TTS via MARS models (mars-pro for quality, mars-flash for speed)
- **Translated TTS service**: Translate text and generate speech in one call via `cambTranslatedTts()`, supporting all 22 of Dubbie's target languages
- **CAMB client and voice catalog**: New `cambClient.ts`, two starter voices in `voicesData.json`
- **Developer experience fixes**: Lazy initialization for Firebase/OpenRouter clients so the backend starts without all credentials configured, local filesystem storage fallback, and relative import fixes for tsx compatibility
- **axios pinned to 1.7.2**: In response to the active supply chain attack on axios@1.14.1

### How to use

1. Get an API key from [studio.camb.ai](https://studio.camb.ai)
2. Set `CAMB_API_KEY` in your environment
3. Select a CAMB voice when creating a project

### Future possibilities

CAMB AI also offers a full dubbing API that handles the entire transcribe-translate-speak pipeline in one call. We'd be happy to add that as an optional "quick dub" mode in a follow-up PR if there's interest.

## Test plan

- [x] CAMB streaming TTS generates valid audio (tested with mars-flash, 18KB mp3)
- [x] CAMB translated TTS translates English to Spanish and generates speech (tested, 188KB wav)
- [x] Existing Azure/OpenAI TTS paths unaffected (optional `language` param is backward-compatible)
- [x] Backend starts without Firebase/OpenRouter credentials
- [ ] Manual test: select a CAMB voice in the UI and generate a dubbed segment